### PR TITLE
fixed situation, when idx > resultVec.size()

### DIFF
--- a/nms.cpp
+++ b/nms.cpp
@@ -203,7 +203,7 @@ vector<int> RemoveByIndexes(const vector<int> & vec,
   auto offset = 0;
   
   for (const auto & idx : idxs) {
-    resultVec.erase(resultVec.begin() + idx + offset);
+    resultVec.erase(resultVec.begin() + (idx + offset));
     offset -= 1;
   }
   


### PR DESCRIPTION
rectangle removal was failed because expression evaluated from left to right and it tried to get iterator out of range