### PR TITLE
Fix for failed of bound index check in MSVC compiler

### DIFF
--- a/nms.cpp
+++ b/nms.cpp
@@ -203,7 +203,7 @@ vector<int> RemoveByIndexes(const vector<int> & vec,
   auto offset = 0;
   
   for (const auto & idx : idxs) {
-    resultVec.erase(resultVec.begin() + idx + offset);
+    resultVec.erase(resultVec.begin() + (idx + offset));
     offset -= 1;
   }
   


### PR DESCRIPTION
Fix for this issue: https://github.com/martinkersner/non-maximum-suppression-cpp/issues/4